### PR TITLE
Update and simplify hyperlink styling

### DIFF
--- a/aesthetic.css
+++ b/aesthetic.css
@@ -15,7 +15,10 @@ textarea,
 select {
   font-size: 20px;
   font-family: Verdana, Geneva, sans-serif;
+  font-weight: 300;
   letter-spacing: -0.01rem;
+  text-decoration: none;
+  line-height: 1.6rem;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;

--- a/aesthetic.css
+++ b/aesthetic.css
@@ -222,7 +222,7 @@ blockquote p:last-of-type {
   height: 100%;
 }
 
-footer>* {
+footer > * {
   display: inline-block;
   margin-right: 0.6rem;
   margin-bottom: 0.6rem;

--- a/aesthetic.css
+++ b/aesthetic.css
@@ -31,6 +31,8 @@ a {
   text-decoration: none;
   position: relative;
   color: #007f6e;
+  border-bottom: 1px solid #007f6e;
+  padding-bottom: 2px;
 }
 
 a:visited {
@@ -39,27 +41,12 @@ a:visited {
 
 a:hover {
   color: #006a5d;
-}
-
-a:before {
-  content: "";
-  position: absolute;
-  height: 1px;
-  width: 100%;
-  background: #007f6e;
-  bottom: -1px;
-}
-
-a:hover::before {
-  background: #003831;
+  border-bottom: 1px solid #006a5d;
 }
 
 a:focus {
   outline: #007f6e auto 1px;
-}
-
-a:focus::before {
-  background: none;
+  border-bottom: none;
 }
 
 nav {
@@ -81,14 +68,12 @@ a.logo {
   font-size: 4rem;
   user-select: none;
   line-height: 1;
+  border-bottom: none;
+  padding-bottom: 0;
 }
 
 a.logo:hover {
   color: #f2c311;
-}
-
-a.logo:before {
-  content: none;
 }
 
 header,


### PR DESCRIPTION
Sometimes I noticed that my custom (and probably unnecessary) hyperlink styling bugged when there is more than tag per line.

This screenshot shows how the first link under `Opia` displays as expected, but the second link for "LG Home Appliance Platform" does not display the custom link styling:

![image](https://user-images.githubusercontent.com/10532380/95974371-cdcb9600-0e0c-11eb-851f-3f1eba3e802a.png)

This PR fixes that weirdness by simplifying the link styling. It's still not applying the default styling from the browser, but it simplifies the usage so that the styling can apply everywhere. Like so:

![image](https://user-images.githubusercontent.com/10532380/95974730-42063980-0e0d-11eb-8827-4514ed9a5043.png)


Additionally, I have increased the line spacing so the site text has more breathing space. I've also tidied up a few bits of styling where I noticed it was a little overcomplicated.

In the near future, I want to reduce the reliance on `px` measurements throughout the style-sheet and use `rem` units instead (where possible).