### PR TITLE
Add custom line heights for each type of heading

### DIFF
--- a/aesthetic.css
+++ b/aesthetic.css
@@ -125,19 +125,21 @@ h1,
 h2,
 h3 {
   margin-bottom: 0.6rem;
-  line-height: 2.6rem;
 }
 
 h1 {
   font-size: 2rem;
+  line-height: 2.4rem;
 }
 
 h2 {
   font-size: 1.8rem;
+  line-height: 2rem;
 }
 
 h3 {
   font-size: 1.4rem;
+  line-height: 1.8rem;
 }
 
 p {

--- a/aesthetic.css
+++ b/aesthetic.css
@@ -14,7 +14,7 @@ button,
 textarea,
 select {
   font-size: 20px;
-  font-family: Verdana, Geneva, sans-serif;
+  font-family: Verdana, sans-serif;
   font-weight: 300;
   letter-spacing: -0.01rem;
   text-decoration: none;


### PR DESCRIPTION
Another PR in the constant battle for ensuring that the spacing is just right. I'll probably never be satisfied, but this is closer to what I want.

Headings on mobile were always a bit too bunched together, and I changed them recently as part of #7 but they still didn't seem quite right. This PR tightens the headings up on smaller displays by providing unique line-heights for each heading type.

It was looking like this on mobile:

![image](https://user-images.githubusercontent.com/10532380/102986710-2902be80-4509-11eb-954f-755b09433022.png)

This seemed a bit too space-y to me, so I've changed them so that headings now look like this on mobile:

![image](https://user-images.githubusercontent.com/10532380/102986564-f35dd580-4508-11eb-8108-ffcb290984af.png)

I've also removed `Geneva` as a fall-back font from the font stack because I only ever use Verdana now in all of my materials (CV, headed letters, documents etc). If the browser can't load Verdana (and it should, because it's a widely used, [websafe font](https://www.w3schools.com/cssref/css_websafe_fonts.asp)) it should simply load the most basic `sans serif` font available.