### PR TITLE
Remove arrow symbol from footer links

### DIFF
--- a/adages.html
+++ b/adages.html
@@ -61,7 +61,7 @@
   </section>
 
   <footer>
-    <p><a href="#">&#916; Scroll back to the top</a></p>
+    <p><a href="#">Scroll back to the top</a></p>
   </footer>
 </body>
 </html>

--- a/questions.html
+++ b/questions.html
@@ -97,7 +97,7 @@
   </article>
 
   <footer>
-    <p><a href="#">&#916; Scroll back to the top</a></p>
+    <p><a href="#">Scroll back to the top</a></p>
   </footer>
 </body>
 </html>

--- a/reviews.html
+++ b/reviews.html
@@ -71,7 +71,7 @@
   </article>
 
   <footer>
-    <p><a href="#">&#916; Scroll back to the top</a></p>
+    <p><a href="#">Scroll back to the top</a></p>
   </footer>
 </body>
 </html>

--- a/timeline.html
+++ b/timeline.html
@@ -318,7 +318,7 @@
   </section>
 
   <footer>
-    <p><a href="#">&#916; Scroll back to the top</a></p>
+    <p><a href="#">Scroll back to the top</a></p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
I don't really use symbols elsewhere in the site design anymore, so these seem a bit out of place.